### PR TITLE
.travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,4 +63,5 @@ jobs:
 env:
   global:
     - CIBW_BEFORE_BUILD="pip install numpy==1.16"
+    - CIBW_TEST_COMMAND="python {project}/starlink/ast/test/test.py"
     - TWINE_USERNAME=sgraves

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,66 @@
 language: python
-sudo: false
-python:
-  - "2.7"
-  - "3.5"
 
 install:
-  - pip install pytest
-  - python setup.py build
-  - python setup.py install
+ - $PIP install --upgrade cibuildwheel==1.0;
 
 script:
-  - py.test starlink/ast/test/test.py
+ - cibuildwheel --output-dir wheelhouse
+ - if [[ $TRAVIS_TAG ]]; then
+     echo $TRAVIS_TAG;
+     brew update;
+     brew install python2;
+     brew link --overwrite python2;
+     sudo $PIP install twine;
+     twine upload --skip-existing wheelhouse/*.whl;
+   fi
+
+jobs:
+    include:
+     - services:
+         - docker
+       python: "3.6"
+       env:  PIP=pip CIBW_BUILD="cp27-*"
+
+     - services:
+         - docker
+       python: "3.6"
+       env:  PIP=pip CIBW_BUILD="cp35-*"
+
+     - services:
+         - docker
+       python: "3.6"
+       env:  PIP=pip CIBW_BUILD="*cp36-*"
+
+     - services:
+         - docker
+       python: "3.6"
+       env:  PIP=pip CIBW_BUILD="cp37-*"
+
+
+
+     - os: osx
+       before_install: brew update;
+       language: generic
+       env:  PIP=pip2 CIBW_BUILD="cp27*"
+
+     - os: osx
+       before_install: brew update;
+       language: generic
+       env:  PIP=pip2 CIBW_BUILD="cp35*"
+
+     - os: osx
+       before_install: brew update;
+       language: generic
+       env:  PIP=pip2 CIBW_BUILD="cp36*"
+
+     - os: osx
+       before_install: brew update;
+       language: generic
+       env:  PIP=pip2 CIBW_BUILD="cp37*"
+
+
+
+env:
+  global:
+    - CIBW_BEFORE_BUILD="pip install numpy==1.16"
+    - TWINE_USERNAME=sgraves

--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,9 @@ setup(name='starlink-pyast',
            'Programming Language :: Python',
            'Programming Language :: C',
           'Topic :: Scientific/Engineering :: Astronomy'
-      ])
+      ],
+      setup_requires=['numpy'],
+      install_requires=['numpy'],)
 
 if os.path.exists(symbol_list):
     os.unlink(symbol_list)

--- a/starlink/ast/test/test.py
+++ b/starlink/ast/test/test.py
@@ -1528,7 +1528,7 @@ class TestAst(unittest.TestCase):
             table['Fred(2)'] = 123
         with self.assertRaises(starlink.Ast.BADTYP):
             table['Fred(2)'] = 123.0
-        table['Fred(2)'] = numpy.linspace(1.0, 10.0, 10.0)
+        table['Fred(2)'] = numpy.linspace(1, 10, 10)
         self.assertEqual(table.columnlength('Fred'), 10)
         self.assertEqual(table.columnndim('Fred'), 2)
         self.assertEqual(table.columnunit('Fred'), '')


### PR DESCRIPTION
This is an updated .travis.yml file, to allow for automated testing on python 2.7, 3.5, 3.6 and 3.7 , and automated binary builds to be pushed to twine if the build passes the test and has a tag. Currently the username in the file is mine, which I'm happy to change if someone else would prefer to have their account there.

I also made a minor change to a test, and added numpy to the setup and install requires.

Someone will also have to approve travis connecting to the Starlink organisation (I'm not an owner so I can't do that). I think there's some more initial  admin on the pypi end as well.